### PR TITLE
Remove chunk base64 check for performance

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,8 @@ export const STFFile = z.object({
   // numChunks: z.number().nonnegative().finite().int(),
 });
 export const STFFileFromClient = STFFile.extend({
-  chunk: z.string().base64(),
+  // Checking base64 string is good for stability, but it slows down the app significantly.
+  chunk: z.string(),
   chunkInd: z.number().nonnegative().finite().int(),
 }).partial({
   id: true,


### PR DESCRIPTION
`base64` check from zod significantly slows the app down.
If I set the chunk size to 4MB, it even emits call stack size exceeded error.
Removing the check improves the performance quite a lot.
Uploading an 1.14GB file took 53s, now just 40s.