### PR TITLE
Increase chunk size for performance

### DIFF
--- a/src/app/upload/useUpload.ts
+++ b/src/app/upload/useUpload.ts
@@ -131,7 +131,7 @@ const useUpload = ({inputRef}: Props) => {
 
       for (const [fileInd, file] of files.entries()) {
         let readBytes = 0;
-        const CHUNK_SIZE = 1024 * 1024;
+        const CHUNK_SIZE = 4 * 1024 * 1024;
         let chunkInd = 0;
         const numChunks = Math.ceil(file.size / CHUNK_SIZE);
         let fileId = '';


### PR DESCRIPTION
Increasing chunk size from 1MB to 4MB.
Most of the time are spent on sending POST request to server.
When sending an 1.14GB file:
```text
`getStfFile`: 5210ms 
`fetch /api/upload`: 34300ms
```

I think it would be better to send large payload with fewer requests would help in this case. 4MB is not big at all as of now.
Also, reading the files in big chunks would also help.
After changing the chunk size, even though it's local, same host, dev server:
```text
`getStfFile`: 3179ms 
`fetch /api/upload`: 24758ms
```

Big improvement.

