### PR TITLE
[#5] Fix dark mode not supported well

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type {Metadata} from 'next';
 import {Roboto} from 'next/font/google';
 import './globals.css';
 import {AppRouterCacheProvider} from '@mui/material-nextjs/v15-appRouter';
+import {ThemeProvider} from '@mui/material';
+import theme from './theme';
 
 const roboto = Roboto({
   weight: ['300', '400', '500', '700'],
@@ -24,7 +26,9 @@ export default function RootLayout ({
     <html lang="en">
       <body className={`${roboto.variable}`}>
         <AppRouterCacheProvider>
-          {children}
+          <ThemeProvider theme={theme}>
+            {children}
+          </ThemeProvider>
         </AppRouterCacheProvider>
       </body>
     </html>

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -1,0 +1,13 @@
+'use client';
+import {createTheme} from '@mui/material';
+
+const theme = createTheme({
+  // This prevents SSR flickers.
+  cssVariables: true,
+  // Enable mui built-in dark scheme from user preferences.
+  colorSchemes: {
+    dark: true,
+  },
+});
+
+export default theme;

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -148,7 +148,18 @@ export default function Upload () {
               }}
               icon={<ContentCopyIcon fontSize='small' />}
             />
-            <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', paddingTop: '30px', paddingBottom: '30px'}}>
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: 'fit-content',
+              height: 'fit-content',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '20px',
+              margin: '10px auto',
+              backgroundColor: 'white',
+              borderRadius: '10px',
+            }}>
               <QRCode value={downloadUrl} size={180} />
             </Box>
           </>


### PR DESCRIPTION
Closes #5.
The cause of the problem is that dark mode is not enabled by default.

By following <https://v6.mui.com/material-ui/customization/dark-mode/#built-in-support>, <https://v6.mui.com/material-ui/integrations/nextjs/#css-theme-variables> and <https://v6.mui.com/material-ui/integrations/nextjs/#font-optimization> I was able to enable the built-in dark mode, fix flicker issues and know how to configure `ThemeProvider` with nextjs.

It changed other colors unexpectedly (e.g. header bgcolor), but right now ¯\\_(ツ)_/¯

<img width="386" height="766" alt="image" src="https://github.com/user-attachments/assets/da07cfe4-20ba-4c8f-a621-9095024b015b" />
