### PR TITLE
[#7] Fix files too low and other styles in upload page

### DIFF
--- a/src/app/upload/page.module.css
+++ b/src/app/upload/page.module.css
@@ -14,7 +14,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 400px;
+    min-width: min(94vw, 400px);
     min-height: 250px;
     border: 1px solid #9999;
     border-radius: 8px;

--- a/src/app/upload/page.module.css
+++ b/src/app/upload/page.module.css
@@ -2,8 +2,9 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    min-height: 80vh;
+    justify-content: flex-end;
+    /* Approx. Center the input area. */
+    min-height: calc(50vh - 56px + 125px);
     padding: 10px 80px;
     gap: 40px;
 }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -85,10 +85,20 @@ export default function Upload () {
       </div>
     </main>
     {!!files?.length &&
-      <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', paddingBottom: '100px'}}>
+      <Box sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '96vw',
+        maxWidth: '400px',
+        paddingBottom: '100px',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+      }}>
         <TextField
           select={true}
-          sx={{margin: '10px', minWidth: '400px'}}
+          sx={{margin: '10px', width: '100%', maxWidth: '400px'}}
           label='This upload will be deleted in:'
           defaultValue={24}
           slotProps={{select: {MenuProps: {disableScrollLock: true}}}}
@@ -103,7 +113,7 @@ export default function Upload () {
           <MenuItem value={168}>One Week</MenuItem>
         </TextField>
         <List
-          sx={{minWidth: '400px', maxWidth: '90vw', border: '1px solid #9999', borderRadius: '8px'}}>
+          sx={{width: '100%', border: '1px solid #9999', borderRadius: '8px'}}>
           {files.map((file, index) => (
             <Fragment key={index}>
               <FileItem key={file.name} file={file} />
@@ -141,28 +151,28 @@ export default function Upload () {
           }
         </DialogContentText>
         {status === 'complete' && <>
-            <Chip
-              label={downloadUrl}
-              onClick={() => {
-                navigator.clipboard.writeText(downloadUrl);
-              }}
-              icon={<ContentCopyIcon fontSize='small' />}
-            />
-            <Box sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              width: 'fit-content',
-              height: 'fit-content',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: '20px',
-              margin: '10px auto',
-              backgroundColor: 'white',
-              borderRadius: '10px',
-            }}>
-              <QRCode value={downloadUrl} size={180} />
-            </Box>
-          </>
+          <Chip
+            label={downloadUrl}
+            onClick={() => {
+              navigator.clipboard.writeText(downloadUrl);
+            }}
+            icon={<ContentCopyIcon fontSize='small' />}
+          />
+          <Box sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: 'fit-content',
+            height: 'fit-content',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '20px',
+            margin: '10px auto',
+            backgroundColor: 'white',
+            borderRadius: '10px',
+          }}>
+            <QRCode value={downloadUrl} size={180} />
+          </Box>
+        </>
         }
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
Closes #7.
- Fix files too low in upload page.
- Fix other styles in upload page (e.g. files and delete date text field overflow on narrow display)